### PR TITLE
chore(gitignore): track hexagonal adapters under src/**/adapters/out …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ amplicode.xml
 # Java/Kotlin build outputs
 *.class
 **/out/
+# but keep adapters/out (hexagonal adapters) tracked
+!**/src/**/adapters/out/
+!**/src/**/adapters/out/**
 
 # Env files
 .env


### PR DESCRIPTION
…by overriding **/out ignore rule